### PR TITLE
Updated readme with branch name change notice

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup golang
-        uses: actions/setup-go@v2-beta
+        uses: actions/setup-go@37335c7bb261b353407cff977110895fa0b4f7d8 # Commit sha for v2.1.3
         with:
           go-version: ${{ matrix.go }}
       - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup golang
-        uses: actions/setup-go@37335c7bb261b353407cff977110895fa0b4f7d8 # Commit sha for v2.1.3
+        uses: actions/setup-go@v2.1.3
         with:
           go-version: ${{ matrix.go }}
       - name: Build

--- a/README.md
+++ b/README.md
@@ -5,6 +5,16 @@
 
 Package for conveniently working with IPv4 and CIDR ranges.
 
+## :rotating_light: NOTICE :rotating_light:
+
+Effective **May 17th 2021** the default branch will change from `master` to `main`. Run the following commands to update a local clone:
+```
+git branch -m master main
+git fetch origin
+git branch -u origin/main main
+git remote set-head origin -
+```
+
 ## Examples
 
 ### Get start and end IPs in a CIDR range:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Effective **May 17th 2021** the default branch will change from `master` to `mai
 git branch -m master main
 git fetch origin
 git branch -u origin/main main
-git remote set-head origin -
+git remote set-head origin -a
 ```
 
 ## Examples


### PR DESCRIPTION
Added notice about the upcoming renaming of the default branch from master to main

Also, updated actions/setup-go to version 2.1.3 (pinned to sha) 
